### PR TITLE
Add web_search/web_fetch to deny lists, fix canvas inconsistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Look for files that don't belong. Relative paths starting with `../../` are a re
 
 | Agent type | Recommended profile | Allow additions | Key denials |
 |-----------|-------------------|----------------|-------------|
-| Group chat bot | `messaging` | `read` (+ `fs.workspaceOnly`), `memory_search`, `image` | `exec`, `bash`, `write`, `edit`, `apply_patch`, `process`, `cron`, `gateway`, `sessions_spawn`, `browser`, `nodes` |
+| Group chat bot | `messaging` | `read` (+ `fs.workspaceOnly`), `memory_search`, `image` | `exec`, `bash`, `write`, `edit`, `apply_patch`, `process`, `cron`, `gateway`, `sessions_spawn`, `browser`, `canvas`, `nodes`, `web_search`, `web_fetch` |
 | Personal assistant (DM only) | `coding` | -- | `gateway`, `cron`, `sessions_spawn` |
 | Read-only information agent | `minimal` | `read` (+ `fs.workspaceOnly`), `memory_search` | Everything else |
 | Monitoring / heartbeat | `minimal` | -- | -- |
@@ -168,7 +168,7 @@ Look for files that don't belong. Relative paths starting with `../../` are a re
   "tools": {
     "profile": "messaging",
     "allow": ["read", "memory_search", "memory_get", "image"],
-    "deny": ["write", "edit", "apply_patch", "exec", "bash", "process", "cron", "gateway", "sessions_spawn", "browser", "nodes"],
+    "deny": ["write", "edit", "apply_patch", "exec", "bash", "process", "cron", "gateway", "sessions_spawn", "browser", "canvas", "nodes", "web_search", "web_fetch"],
     "fs": {
       "workspaceOnly": true
     },
@@ -722,7 +722,8 @@ Complete configuration snippet for a group chat bot agent. Merge it into the rel
     "allow": ["read", "memory_search", "memory_get", "image"],
     "deny": [
       "write", "edit", "apply_patch", "exec", "bash", "process",
-      "cron", "gateway", "sessions_spawn", "browser", "nodes"
+      "cron", "gateway", "sessions_spawn", "browser", "canvas", "nodes",
+      "web_search", "web_fetch"
     ],
     "fs": {
       "workspaceOnly": true

--- a/examples/group-chat-bot.json
+++ b/examples/group-chat-bot.json
@@ -26,7 +26,9 @@
       "sessions_spawn",
       "browser",
       "canvas",
-      "nodes"
+      "nodes",
+      "web_search",
+      "web_fetch"
     ],
 
     "fs": {

--- a/examples/read-only-agent.json
+++ b/examples/read-only-agent.json
@@ -26,6 +26,8 @@
       "browser",
       "canvas",
       "nodes",
+      "web_search",
+      "web_fetch",
       "message",
       "image"
     ],


### PR DESCRIPTION
## Summary

- Adds `web_search` and `web_fetch` to all deny arrays (README Sections 3 + 9, both example configs)
- Fixes `canvas` inconsistency: example files already denied it, README inline snippets did not
- Updates decision matrix to list all denied tools for group chat bots

The `group:web` tools are data exfiltration vectors. A group chat bot with `web_fetch` can be tricked via prompt injection into sending data to attacker-controlled URLs.

Closes #1

## Test plan

- [ ] Verify all four deny arrays include `web_search`, `web_fetch`, and `canvas`
- [ ] Validate JSON: `jq . examples/group-chat-bot.json && jq . examples/read-only-agent.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)